### PR TITLE
Fix java.lang.UnsupportedOperationException when using Snippet Genera…

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -136,7 +136,7 @@ public class StashBuildTrigger extends Trigger<Job<?, ?>> {
   }
 
   // Needed for Jelly Config
-  public String getcredentialsId() {
+  public String getCredentialsId() {
     return this.credentialsId;
   }
 


### PR DESCRIPTION
When using the Jenkins snippet generator for your pipeline job (http://my-jenkins:8080/job/my-pipeline-job/pipeline-syntax/), you can configure the Stash Pull Requests Builder via the option 'properties: Set job properties' and then 'Build Triggers'.
When generating the script it will give you: 
`"properties([pipelineTriggers([<object of type stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger>])])"`

Following stacktrace is found in the log:

**java.lang.UnsupportedOperationException: no public field credentialsId (or getter method) found in class stashpullrequestbuilder.stashpullrequestbuilder.StashBuildTrigger
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.getValue(DescribableParameter.java:161)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.inspect(DescribableParameter.java:142)
        at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2(DescribableModel.java:584)
        at org.jenkinsci.plugins.structs.describable.DescribableModel.uninstantiate2_(DescribableModel.java:675)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.uncoerce(DescribableParameter.java:196)
        at org.jenkinsci.plugins.structs.describable.DescribableParameter.uncoerce(DescribableParameter.java:190)`**