### PR TITLE
Fix stashBuildTrigger as a pipelineTrigger in a pipeline script

### DIFF
--- a/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
+++ b/src/main/java/stashpullrequestbuilder/stashpullrequestbuilder/StashBuildTrigger.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -71,9 +72,6 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
   private boolean checkProbeMergeStatus;
 
   private transient StashPullRequestsBuilder stashPullRequestsBuilder;
-
-  @Extension
-  public static final StashBuildTriggerDescriptor descriptor = new StashBuildTriggerDescriptor();
 
   @DataBoundConstructor
   public StashBuildTrigger(
@@ -332,6 +330,8 @@ public class StashBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     return onlyBuildOnComment;
   }
 
+  @Extension
+  @Symbol("stashBuildTrigger")
   public static final class StashBuildTriggerDescriptor extends TriggerDescriptor {
     public StashBuildTriggerDescriptor() {
       load();


### PR DESCRIPTION
Fix java.lang.NoSuchMethodError when using stashBuildTrigger as a pipelineTrigger in a pipeline script

e.g.
`properties([
        pipelineTriggers([
                stashBuildTrigger(
                    projectPath: null,
                    cron: "* * * * *",
                    stashHost: "https://my-stash",
                    credentialsId: 'my-credentialsId',
                    projectCode: "my-project-code",
                    repositoryName: "my-repository",
                    ciSkipPhrases: "NO TEST",
                    ignoreSsl: true,
                    checkDestinationCommit: false,
                    checkMergeable: false,
                    mergeOnSuccess: false,
                    checkNotConflicted: true,
                    onlyBuildOnComment: true,
                    ciBuildPhrases: "test this please",
                    deletePreviousBuildFinishComments: false,
                    targetBranchesToBuild: null,
                    cancelOutdatedJobsEnabled: false
                )
        ])
])
`

java.lang.NoSuchMethodError: No such DSL method 'stashBuildTrigger' found among steps [archive, bat, build, catchError, ...

	at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:199)
	at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:122)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)